### PR TITLE
Support multiple update document types

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -39,6 +39,8 @@ pub use self::list_databases::ListDatabases;
 pub use self::list_indexes::ListIndexes;
 pub use self::ping::Ping;
 pub use self::update::Update;
+pub use self::update::UpdateDoc;
+pub use self::update::UpdateOper;
 pub use self::whats_my_uri::WhatsMyUri;
 
 pub trait Handler {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -38,6 +38,7 @@ pub use self::list_collections::ListCollections;
 pub use self::list_databases::ListDatabases;
 pub use self::list_indexes::ListIndexes;
 pub use self::ping::Ping;
+pub use self::update::InvalidUpdateError;
 pub use self::update::Update;
 pub use self::update::UpdateDoc;
 pub use self::update::UpdateOper;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -38,6 +38,7 @@ pub use self::list_collections::ListCollections;
 pub use self::list_databases::ListDatabases;
 pub use self::list_indexes::ListIndexes;
 pub use self::ping::Ping;
+pub use self::update::collapse_fields;
 pub use self::update::InvalidUpdateError;
 pub use self::update::Update;
 pub use self::update::UpdateDoc;

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -1,9 +1,44 @@
 #![allow(dead_code)]
 use crate::handler::{CommandExecutionError, Request};
+use crate::pg::InvalidUpdateError;
 use crate::{commands::Handler, pg::SqlParam};
 use bson::{doc, Bson, Document};
 
 pub struct Update {}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum UpdateOper {
+    Update(Vec<UpdateDoc>),
+    Replace(Document),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum UpdateDoc {
+    Set(Document),
+    Inc(Document),
+}
+
+impl UpdateDoc {
+    fn validate(&self) -> Result<UpdateDoc, InvalidUpdateError> {
+        match self {
+            UpdateDoc::Set(doc) => match expand_fields(doc) {
+                Ok(u) => Ok(UpdateDoc::Set(u)),
+                Err(e) => {
+                    return Err(InvalidUpdateError::new(format!(
+                        "Cannot update '{}' and '{}' at the same time",
+                        e.target, e.source
+                    )));
+                }
+            },
+            _ => {
+                return Err(InvalidUpdateError::new(format!(
+                    "Unhandled update operation: {:?}",
+                    self
+                )));
+            }
+        }
+    }
+}
 
 impl Handler for Update {
     fn new() -> Self {
@@ -27,26 +62,16 @@ impl Handler for Update {
         for update in updates {
             let doc = update.as_document().unwrap();
             let q = doc.get_document("q").unwrap();
-            let u = doc.get_document("u").unwrap();
-
-            let set = match expand_fields(u.get_document("$set").unwrap()) {
-                Ok(u) => u,
-                Err(e) => {
-                    return Err(CommandExecutionError {
-                        message: format!(
-                            "Cannot update '{}' and '{}' at the same time",
-                            e.target, e.source
-                        ),
-                    })
-                }
-            };
-
-            let mut u = u.clone();
-            u.insert("$set", set);
-
+            let update_doc = parse_update(doc.get_document("u").unwrap());
             let multi = doc.get_bool("multi").unwrap_or(true);
 
-            n += client.update(&sp, Some(q), &u, multi).unwrap();
+            if update_doc.is_err() {
+                return Err(CommandExecutionError::new(format!("{:?}", update_doc)));
+            }
+
+            n += client
+                .update(&sp, Some(q), update_doc.unwrap(), multi)
+                .unwrap();
         }
 
         Ok(doc! {
@@ -121,6 +146,43 @@ fn get_path(doc: &Document, path: String) -> Option<&Bson> {
     None
 }
 
+fn parse_update(doc: &Document) -> Result<UpdateOper, InvalidUpdateError> {
+    let mut res: Vec<UpdateDoc> = vec![];
+    if !doc.keys().any(|k| k.starts_with("$")) {
+        return Ok(UpdateOper::Replace(doc.clone()));
+    }
+    for (key, value) in doc.iter() {
+        match key.as_str() {
+            "$set" => {
+                let expanded_doc = match expand_fields(value.as_document().unwrap()) {
+                    Ok(doc) => doc,
+                    Err(e) => {
+                        return Err(InvalidUpdateError::new(format!(
+                            "Cannot update '{}' and '{}' at the same time",
+                            e.target, e.source
+                        )));
+                    }
+                };
+                match UpdateDoc::Set(expanded_doc).validate() {
+                    Ok(update_doc) => res.push(update_doc),
+                    Err(e) => {
+                        return Err(InvalidUpdateError::new(format!("{:?}", e)));
+                    }
+                }
+            }
+            _ => {
+                if key.starts_with("$") || res.len() > 0 {
+                    return Err(InvalidUpdateError::new(format!(
+                        "Unknown modifier: {}",
+                        key
+                    )));
+                }
+            }
+        }
+    }
+    Ok(UpdateOper::Update(res))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -166,5 +228,30 @@ mod tests {
         let err = expanded.unwrap_err();
         assert_eq!(err.source, "a.b.c");
         assert_eq!(err.target, "a.b");
+    }
+
+    #[test]
+    fn test_parse_update() {
+        let set_doc = doc! { "$set": { "a": 1 } };
+        let repl_doc = doc! { "b": 2, "c": 8, "d": 9 };
+        let unknown_doc = doc! { "$xyz": { "a": 1 } };
+        let mixed_doc = doc! { "$set": { "x": 1 }, "b": 2 };
+
+        assert_eq!(
+            parse_update(&set_doc).unwrap(),
+            UpdateOper::Update(vec![UpdateDoc::Set(doc! { "a": 1 })])
+        );
+        assert_eq!(
+            parse_update(&repl_doc).unwrap(),
+            UpdateOper::Replace(repl_doc)
+        );
+        assert_eq!(
+            parse_update(&unknown_doc).unwrap_err(),
+            InvalidUpdateError::new("Unknown modifier: $xyz".to_string())
+        );
+        assert_eq!(
+            parse_update(&mixed_doc).unwrap_err(),
+            InvalidUpdateError::new("Unknown modifier: b".to_string())
+        );
     }
 }

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -1,6 +1,5 @@
 #![allow(dead_code)]
 use crate::handler::{CommandExecutionError, Request};
-use crate::pg::InvalidUpdateError;
 use crate::{commands::Handler, pg::SqlParam};
 use bson::{doc, Bson, Document};
 
@@ -16,6 +15,17 @@ pub enum UpdateOper {
 pub enum UpdateDoc {
     Set(Document),
     Inc(Document),
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct InvalidUpdateError {
+    reason: String,
+}
+
+impl InvalidUpdateError {
+    pub fn new(reason: String) -> Self {
+        InvalidUpdateError { reason }
+    }
 }
 
 impl UpdateDoc {

--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -76,7 +76,7 @@ impl Handler for Update {
             let doc = update.as_document().unwrap();
             let q = doc.get_document("q").unwrap();
             let update_doc = parse_update(doc.get_document("u").unwrap());
-            let multi = doc.get_bool("multi").unwrap_or(true);
+            let multi = doc.get_bool("multi").unwrap_or(false);
 
             if update_doc.is_err() {
                 return Err(CommandExecutionError::new(format!("{:?}", update_doc)));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -103,6 +103,8 @@ fn parse_expression_tree(exp_tree: ExpressionTreeClause) -> String {
     let operator = match exp_tree.operator.as_str() {
         "$and" => "AND",
         "$or" => "OR",
+        // FIXME handle $nor expression
+        // #17 - https://github.com/fcoury/oxide/issues/17
         // "$nor" => "NOR", FIXME
         t => unimplemented!("parse_expression_tree operator unimplemented = {:?}", t),
     };

--- a/src/pg.rs
+++ b/src/pg.rs
@@ -150,6 +150,7 @@ impl PgDb {
         };
 
         // FIXME start a transaction here
+        // #16 - https://github.com/fcoury/oxide/issues/16
         let mut total = 0;
         for sql in statements {
             match self.exec(&sql, &[]) {

--- a/src/pg.rs
+++ b/src/pg.rs
@@ -186,8 +186,16 @@ impl PgDb {
                 }
                 statements
             }
-            UpdateOper::Replace(_replace) => {
-                todo!()
+            UpdateOper::Replace(replace) => {
+                let json = Bson::Document(replace).into_psql_json();
+                let sql = format!(
+                    "{}UPDATE {} SET _jsonb = $1 {}{}",
+                    prefix, table_name, from, where_str
+                );
+                return match self.exec(&sql, &[&json]) {
+                    Ok(count) => Ok(count),
+                    Err(e) => Err(UpdateError::Other(e)),
+                };
             }
         };
 

--- a/src/pg.rs
+++ b/src/pg.rs
@@ -93,23 +93,23 @@ impl PgDb {
         };
 
         let table_name = format!("{} t", sp.sanitize());
-        let mut prefix = "".to_string();
-        let mut from = "".to_string();
         if !multi {
-            prefix = format!(
-                indoc! {"
-                    WITH cte AS (
-                        SELECT _jsonb
-                        FROM   {}
-                        {}
-                        LIMIT 1
-                    )
-                "},
-                sp.sanitize(),
-                where_str
+            // gets the first id that matches
+            let sql = format!(
+                "SELECT _jsonb->'_id'->>'$o' FROM {} {} LIMIT 1",
+                table_name, where_str
             );
-            from = " FROM cte".to_string();
-            where_str = " WHERE t._jsonb = cte._jsonb".to_string();
+            let rows = self.raw_query(&sql, &[]).unwrap();
+            if rows.len() < 1 {
+                return Ok(0);
+            }
+            let id: String = rows[0].get(0);
+            let match_id = format!("_jsonb->'_id'->>'$o' = '{}'", id);
+            if where_str == "" {
+                where_str = format!(" WHERE {}", match_id);
+            } else {
+                where_str = format!("{} AND {}", where_str, match_id);
+            }
         };
 
         let statements = match update {
@@ -128,10 +128,7 @@ impl PgDb {
                                 .collect::<Vec<String>>()
                                 .join(", ");
 
-                            let sql = format!(
-                                "{}UPDATE {} SET {}{}{}",
-                                prefix, table_name, updates, from, where_str
-                            );
+                            let sql = format!("UPDATE {} SET {}{}", table_name, updates, where_str);
                             statements.push(sql);
                         }
                         UpdateDoc::Unset(unset) => {
@@ -147,11 +144,9 @@ impl PgDb {
                             }
 
                             let sql = format!(
-                                "{}UPDATE {} SET _jsonb = _jsonb{}{}{}",
-                                prefix,
+                                "UPDATE {} SET _jsonb = _jsonb{}{}",
                                 table_name,
                                 removals.join(""),
-                                from,
                                 where_str
                             );
                             statements.push(sql);
@@ -172,13 +167,12 @@ impl PgDb {
 
                             let sql = format!(
                                 indoc! {"
-                                {}UPDATE {}
+                                UPDATE {}
                                 SET _jsonb = _jsonb ||
                                     {}
                                 {}
-                                {}
                             "},
-                                prefix, table_name, updates, from, where_str
+                                table_name, updates, where_str
                             );
                             statements.push(sql);
                         }
@@ -188,10 +182,7 @@ impl PgDb {
             }
             UpdateOper::Replace(replace) => {
                 let json = Bson::Document(replace).into_psql_json();
-                let sql = format!(
-                    "{}UPDATE {} SET _jsonb = $1 {}{}",
-                    prefix, table_name, from, where_str
-                );
+                let sql = format!("UPDATE {} SET _jsonb = $1 {}", table_name, where_str);
                 return match self.exec(&sql, &[&json]) {
                     Ok(count) => Ok(count),
                     Err(e) => Err(UpdateError::Other(e)),

--- a/src/pg.rs
+++ b/src/pg.rs
@@ -112,7 +112,21 @@ impl PgDb {
                                 format!("UPDATE {} SET {}{}", sp.sanitize(), updates, where_str);
                             statements.push(sql);
                         }
-                        // $inc: { a: 2, b: 3, c: 1 }
+                        UpdateDoc::Unset(unset) => {
+                            let removals = unset
+                                .keys()
+                                .map(|k| format!("'{}'", k))
+                                .collect::<Vec<String>>()
+                                .join(" - ");
+
+                            let sql = format!(
+                                "UPDATE {} SET _jsonb = _jsonb - {}{}",
+                                sp.sanitize(),
+                                removals,
+                                where_str
+                            );
+                            statements.push(sql);
+                        }
                         UpdateDoc::Inc(inc) => {
                             let updates = inc
                                 .iter()

--- a/src/pg.rs
+++ b/src/pg.rs
@@ -1,5 +1,5 @@
 #![allow(dead_code)]
-use crate::commands::{UpdateDoc, UpdateOper};
+use crate::commands::{InvalidUpdateError, UpdateDoc, UpdateOper};
 use crate::parser::value_to_jsonb;
 use crate::serializer::PostgresSerializer;
 use bson::{Bson, Document};
@@ -15,17 +15,6 @@ use std::fmt;
 #[derive(Debug)]
 pub struct AlreadyExistsError {
     target: String,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub struct InvalidUpdateError {
-    reason: String,
-}
-
-impl InvalidUpdateError {
-    pub fn new(reason: String) -> Self {
-        InvalidUpdateError { reason }
-    }
 }
 
 #[derive(Debug)]

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -70,7 +70,7 @@ pub fn setup_with_pg_db(name: &str) -> TestContext {
     let port: u16 = portpicker::pick_unused_port().unwrap();
 
     let manager = PostgresConnectionManager::new(pg_url.parse().unwrap(), NoTls);
-    let pool = r2d2::Pool::new(manager).unwrap();
+    let pool = r2d2::Pool::builder().max_size(2).build(manager).unwrap();
     PgDb::new_from_pool(pool.clone())
         .drop_schema("db_test")
         .unwrap();

--- a/tests/update_test.rs
+++ b/tests/update_test.rs
@@ -312,3 +312,31 @@ fn test_update_multi_off() {
 
     assert_eq!(results.len(), 1);
 }
+
+#[test]
+fn test_update_one_with_replacement_document() {
+    let ctx = common::setup();
+
+    ctx.col()
+        .insert_many(
+            vec![doc! { "x": 1, "y": 2 }, doc! { "x": 2 }, doc! { "x": 3 }],
+            None,
+        )
+        .unwrap();
+
+    ctx.col()
+        .replace_one(doc! { "x": 1 }, doc! { "new_key": "oh_yes" }, None)
+        .unwrap();
+
+    let cursor = ctx.col().find(doc! { "x": 1 }, None).unwrap();
+    let results = cursor.collect::<Vec<_>>();
+    assert_eq!(results.len(), 0);
+
+    let cursor = ctx.col().find(doc! { "x": 2 }, None).unwrap();
+    let results = cursor.collect::<Vec<_>>();
+    assert_eq!(results.len(), 1);
+
+    let cursor = ctx.col().find(doc! { "new_key": "oh_yes" }, None).unwrap();
+    let results = cursor.collect::<Vec<_>>();
+    assert_eq!(results[0].clone().unwrap(), doc! { "new_key": "oh_yes" });
+}

--- a/tests/update_test.rs
+++ b/tests/update_test.rs
@@ -179,11 +179,44 @@ fn test_update_with_inc_double_fields() {
     let row2 = res.next().unwrap().unwrap();
     assert_eq!(row2.get_i32("v").unwrap(), 12);
     assert_eq!(row2.get_f64("z").unwrap(), 8.2);
-    */
 }
 
 #[test]
 #[ignore]
 fn test_update_inc_with_nested_fields() {
     todo!("nested fields are exanded but we don't consider those when building the update clause");
+}
+
+#[test]
+fn test_update_unset() {
+    let ctx = common::setup();
+
+    ctx.col()
+        .insert_many(
+            vec![
+                doc! { "idx": 1, "one": 1, "v": 1, "z": 1.5 },
+                doc! { "idx": 2, "one": 1, "v": 2, "z": 10.2 },
+                doc! { "idx": 3, "three": "three", "v": 0, "z": 100 },
+            ],
+            None,
+        )
+        .unwrap();
+
+    ctx.col()
+        .update_many(doc! { "one": 1 }, doc! { "$unset": { "v": 1 } }, None)
+        .unwrap();
+
+    let mut res = ctx.col().find(doc! { "idx": 1 }, None).unwrap();
+    let row1 = res.next().unwrap().unwrap();
+    assert_eq!(row1.get("v"), None);
+    assert_eq!(row1.get_f64("z").unwrap(), 1.5);
+
+    let mut res = ctx.col().find(doc! { "idx": 2 }, None).unwrap();
+    let row2 = res.next().unwrap().unwrap();
+    assert_eq!(row2.get("v"), None);
+    assert_eq!(row2.get_f64("z").unwrap(), 10.2);
+
+    let mut res = ctx.col().find(doc! { "idx": 3 }, None).unwrap();
+    let row3 = res.next().unwrap().unwrap();
+    assert_eq!(row3.get_i32("v").unwrap(), 0);
 }

--- a/tests/update_test.rs
+++ b/tests/update_test.rs
@@ -61,7 +61,10 @@ fn test_update_with_conflicting_nested_keys() {
     );
 
     assert!(res.is_err());
-    assert_eq!(res.unwrap_err().to_string(), "Command failed (CommandNotFound): Cannot update 'field.y.z' and 'field.z' at the same time)");
+    assert!(res
+        .unwrap_err()
+        .to_string()
+        .contains("Cannot update 'field.y.z' and 'field.z' at the same time"));
 }
 
 #[test]
@@ -79,8 +82,8 @@ fn test_update_with_conflicting_keys() {
     );
 
     assert!(res.is_err());
-    assert_eq!(
-        res.unwrap_err().to_string(),
-        "Command failed (CommandNotFound): Cannot update 'field' and 'field.z' at the same time)"
-    );
+    assert!(res
+        .unwrap_err()
+        .to_string()
+        .contains("Cannot update 'field' and 'field.z' at the same time"));
 }

--- a/tests/update_test.rs
+++ b/tests/update_test.rs
@@ -291,3 +291,24 @@ fn test_update_unset_nested_fields() {
     assert_eq!(doc.get("remove"), None);
     assert_eq!(doc.get_i32("keep").unwrap(), 1);
 }
+
+#[test]
+fn test_update_multi_off() {
+    let ctx = common::setup();
+
+    ctx.col()
+        .insert_many(
+            vec![doc! { "x": 1 }, doc! { "x": 1 }, doc! { "x": 1 }],
+            None,
+        )
+        .unwrap();
+
+    ctx.col()
+        .update_one(doc! { "x": 1 }, doc! { "$set": { "x": 10 } }, None)
+        .unwrap();
+
+    let cursor = ctx.col().find(doc! { "x": 10 }, None).unwrap();
+    let results = cursor.collect::<Vec<_>>();
+
+    assert_eq!(results.len(), 1);
+}

--- a/tests/update_test.rs
+++ b/tests/update_test.rs
@@ -147,8 +147,10 @@ fn test_update_with_inc_multiple_fields() {
 #[test]
 #[ignore]
 fn test_update_with_inc_double_fields() {
-    todo!("double fields need to be casted properly with $f");
-    /*
+    // FIXME We have to change how updates work, instead of doing
+    //       them in batch, we'll have to get one doc, update it
+    //       and so on.
+    // #16 - https://github.com/fcoury/oxide/issues/16
     let ctx = common::setup();
 
     ctx.col()


### PR DESCRIPTION
Advanced support for `update` part for the the `update()` command as described by MongoDB documentation:

https://www.mongodb.com/docs/manual/reference/method/db.collection.update/#std-label-update-parameter

To include support for replacement objects and the main operators for the list:

https://www.mongodb.com/docs/manual/reference/operator/update/#std-label-update-operators

Initially `$set`, `$inc` and `$unset`.