### PR TITLE
Fix numeric comparators crashing when documents have a mix of numeric and non-numeric contents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
       - 'feature-**'
+      - 'fix-**'
 
 jobs:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "time 0.3.11",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -740,7 +740,7 @@ dependencies = [
  "trust-dns-proto",
  "trust-dns-resolver",
  "typed-builder",
- "uuid",
+ "uuid 0.8.2",
  "webpki-roots",
 ]
 
@@ -848,6 +848,7 @@ dependencies = [
  "serde_json",
  "sql_lexer",
  "tokio",
+ "uuid 1.1.2",
 ]
 
 [[package]]
@@ -1730,6 +1731,28 @@ checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
  "getrandom",
  "serde",
+]
+
+[[package]]
+name = "uuid"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
+dependencies = [
+ "getrandom",
+ "rand",
+ "uuid-macro-internal",
+]
+
+[[package]]
+name = "uuid-macro-internal"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "548f7181a5990efa50237abb7ebca410828b57a8955993334679f8b50b35c97d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,11 @@ serde = "1"
 serde_json = {version = "1", features = ["preserve_order"]}
 sql_lexer = "0.9.3"
 tokio = "1"
+
+[dependencies.uuid]
+features = [
+  "v4", # Lets you generate random UUIDs
+  "fast-rng", # Use a faster (but still sufficiently random) RNG
+  "macro-diagnostics", # Enable better diagnostics for compile-time UUIDs
+]
+version = "1.1.2"

--- a/src/commands/insert.rs
+++ b/src/commands/insert.rs
@@ -20,6 +20,7 @@ impl Handler for Insert {
         let docs = doc.get_array("documents").unwrap();
 
         let mut client = request.get_client();
+        client.create_schema_if_not_exists(db).unwrap();
         client.create_table_if_not_exists(db, collection).unwrap();
 
         let sp = SqlParam::new(db, collection);

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -5,7 +5,6 @@ use oxide::server::Server;
 use r2d2_postgres::{postgres::NoTls, PostgresConnectionManager};
 use std::io::{Read, Write};
 use std::net::{Shutdown, TcpStream};
-use std::time::{SystemTime, UNIX_EPOCH};
 use std::{env, thread};
 
 #[derive(Debug, Clone)]
@@ -18,11 +17,8 @@ pub struct TestContext {
 
 impl TestContext {
     pub fn new(port: u16, db: String) -> Self {
-        let id = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let collection = format!("test_collection_{}", id).to_string();
+        let id = uuid::Uuid::new_v4().to_string();
+        let collection = format!("test_{}", id).to_string();
         let client_uri = format!("mongodb://localhost:{}/test", port);
         let mongodb = mongodb::sync::Client::with_uri_str(&client_uri).unwrap();
 

--- a/tests/find_test.rs
+++ b/tests/find_test.rs
@@ -154,6 +154,5 @@ fn test_find_type_bracketing() {
         .find(doc! { "counter": { "$gt": 1 } }, None)
         .unwrap();
     let rows: Vec<Result<Document, mongodb::error::Error>> = cursor.collect();
-    println!("{:?}", rows);
     assert_eq!(1, rows.len());
 }

--- a/tests/find_test.rs
+++ b/tests/find_test.rs
@@ -133,3 +133,27 @@ fn test_find_with_gt_float() {
             .unwrap()
     );
 }
+
+#[test]
+fn test_find_type_bracketing() {
+    let ctx = common::setup();
+
+    ctx.col()
+        .insert_many(
+            vec![
+                doc! { "counter": 1 },
+                doc! { "counter": "Str" },
+                doc! { "counter": 3 },
+            ],
+            None,
+        )
+        .unwrap();
+
+    let cursor = ctx
+        .col()
+        .find(doc! { "counter": { "$gt": 1 } }, None)
+        .unwrap();
+    let rows: Vec<Result<Document, mongodb::error::Error>> = cursor.collect();
+    println!("{:?}", rows);
+    assert_eq!(1, rows.len());
+}


### PR DESCRIPTION
Fixes #19