### PR TITLE
Handles upsert for replacement documents

### DIFF
--- a/src/commands/update.rs
+++ b/src/commands/update.rs
@@ -77,6 +77,7 @@ impl Handler for Update {
             let doc = update.as_document().unwrap();
             let q = doc.get_document("q").unwrap();
             let update_doc = parse_update(doc.get_document("u").unwrap());
+            let upsert = doc.get_bool("upsert").unwrap_or(false);
             let multi = doc.get_bool("multi").unwrap_or(false);
 
             if update_doc.is_err() {
@@ -84,7 +85,7 @@ impl Handler for Update {
             }
 
             n += client
-                .update(&sp, Some(q), update_doc.unwrap(), multi)
+                .update(&sp, Some(q), update_doc.unwrap(), upsert, multi)
                 .unwrap();
         }
 

--- a/tests/list_databases_test.rs
+++ b/tests/list_databases_test.rs
@@ -4,7 +4,7 @@ mod common;
 
 #[test]
 fn test_list_database() {
-    let ctx = common::setup_with_pg_db("test_list_1");
+    let ctx = common::setup_with_pg_db("test_list_1", true);
 
     // initially only public database is listed
     let res = ctx.mongodb().list_databases(None, None).unwrap();
@@ -23,7 +23,7 @@ fn test_list_database() {
 
 #[test]
 fn test_list_database_name_only() {
-    let ctx = common::setup_with_pg_db("test_list_2");
+    let ctx = common::setup_with_pg_db("test_list_2", true);
 
     let res = ctx.mongodb().list_database_names(None, None).unwrap();
     assert_eq!(res.len(), 1);
@@ -32,7 +32,7 @@ fn test_list_database_name_only() {
 
 #[test]
 fn test_list_database_with_table_with_spaces() {
-    let ctx = common::setup_with_pg_db("test_list_3");
+    let ctx = common::setup_with_pg_db("test_list_3", true);
 
     ctx.db()
         .collection("my col")

--- a/tests/update_test.rs
+++ b/tests/update_test.rs
@@ -1,4 +1,4 @@
-use mongodb::bson::doc;
+use mongodb::{bson::doc, options::ReplaceOptions};
 
 mod common;
 
@@ -339,6 +339,25 @@ fn test_update_one_with_replacement_document() {
     let cursor = ctx.col().find(doc! { "new_key": "oh_yes" }, None).unwrap();
     let results = cursor.collect::<Vec<_>>();
     assert_eq!(results[0].clone().unwrap(), doc! { "new_key": "oh_yes" });
+}
+
+#[test]
+fn test_upsert() {
+    let ctx = common::setup();
+    let res = ctx
+        .col()
+        .replace_one(
+            doc! { "x": 1 },
+            doc! { "x": 1, "y": 2 },
+            ReplaceOptions::builder().upsert(true).build(),
+        )
+        .unwrap();
+    let count = res.modified_count;
+    assert_eq!(count, 1);
+
+    let cursor = ctx.col().find(doc! { "x": 1 }, None).unwrap();
+    let results = cursor.collect::<Vec<_>>();
+    assert_eq!(results.len(), 1);
 }
 
 #[test]


### PR DESCRIPTION
We now handle upsert flag for replacement documents, but work is still necessary for other operations, like `$set`. We need to research if it's allowed and the logic behind each operation if so.

https://github.com/fcoury/oxide/issues/24