### PR TITLE
Spelling

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -305,7 +305,7 @@ fn parse_object(field: &str, object: &Map<String, serde_json::Value>) -> Result<
                 "$in" | "$nin" => {
                     if !v.is_array() {
                         // FIXME error this out
-                        todo!("Return an error when exists does't have an array");
+                        todo!("Return an error when exists doesn't have an array");
                     }
 
                     let field = parts

--- a/tests/update_test.rs
+++ b/tests/update_test.rs
@@ -182,7 +182,7 @@ fn test_update_with_inc_double_fields() {
 #[test]
 #[ignore]
 fn test_update_inc_with_nested_fields() {
-    todo!("nested fields are exanded but we don't consider those when building the update clause");
+    todo!("nested fields are expanded but we don't consider those when building the update clause");
 }
 
 #[test]


### PR DESCRIPTION
This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/oxide/commit/c962f0aefd60a55fe79d03f6dc8254719cac03d0#commitcomment-80112315

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/oxide/commit/22e21092ec446b932081e31f481f8cbd0971eb87

Note: this PR does not include the action. If you're interested in running a spell check on every PR and push, that can be offered separately.