### PR TITLE
fix: allows creating indexes on nested fields using `parent.child` notation

### DIFF
--- a/src/pg.rs
+++ b/src/pg.rs
@@ -510,14 +510,23 @@ impl PgDb {
             .get_document("key")
             .unwrap()
             .into_iter()
-            .map(|(k, _)| format!("(_jsonb->'{}')", k))
+            .map(|(k, _)| {
+                format!(
+                    "(_jsonb->{})",
+                    k.split(".")
+                        .into_iter()
+                        .map(|k| format!("'{}'", k))
+                        .collect::<Vec<_>>()
+                        .join("->")
+                )
+            })
             .collect();
         let unique = if index.get_bool("unique").unwrap_or(false) {
             " UNIQUE"
         } else {
             ""
         };
-        let name = index.get_str("name").unwrap();
+        let name = index.get_str("name").unwrap().replace(".", "_");
         let sql = format!(
             "CREATE{} INDEX IF NOT EXISTS {} ON {} ({})",
             unique,

--- a/tests/create_indexes_test.rs
+++ b/tests/create_indexes_test.rs
@@ -47,3 +47,26 @@ fn create_indexes_test_already_existing() {
         .unwrap();
     assert_eq!(index.keys, doc! { "a": 1, "b": 1 });
 }
+
+#[test]
+fn create_nested_index() {
+    let ctx = common::setup();
+
+    let model = IndexModel::builder()
+        .keys(doc! { "a.z": 1, "b.c.d": 1 })
+        .build();
+    let options = None;
+    ctx.col().create_index(model, options).unwrap();
+
+    let cursor = ctx.col().list_indexes(None).unwrap();
+    let indexes = cursor
+        .collect::<Vec<_>>()
+        .iter()
+        .map(|x| x.clone().unwrap())
+        .collect::<Vec<_>>();
+    let index = indexes
+        .iter()
+        .find(|x| x.keys == doc! { "a.z": 1, "b.c.d": 1 })
+        .unwrap();
+    assert_eq!(index.keys, doc! { "a.z": 1, "b.c.d": 1 });
+}


### PR DESCRIPTION
Fixes #60 