### PR TITLE
Matches arrays when searching for nested fields

### DIFF
--- a/tests/find_test.rs
+++ b/tests/find_test.rs
@@ -287,3 +287,13 @@ fn test_with_multiple_fields() {
     assert_eq!(1, rows[0].get_i32("counter").unwrap());
     assert_eq!(1, rows[0].get_i32("a").unwrap());
 }
+
+#[test]
+fn test_with_array() {
+    let col = insert!(doc! { "loginTokens": [{"when": "now", "token": "TOKEN_VALUE"}] });
+    let rows = common::get_rows(
+        col.find(doc! { "loginTokens.token": "TOKEN_VALUE" }, None)
+            .unwrap(),
+    );
+    assert_eq!(1, rows.len());
+}


### PR DESCRIPTION
For a query like `{"a.b.c": 1}`, MongoDB matches a document where the field `"b"` is an array containing the object `{"c": 1}`.

This case is handled by this PR. 

We also need to investigate the broader case where it should also match the following objects:

{"a": [{"b": {"c": 1}}]}
{"a": [{"b": [{"c": 1}]}]}

Those other cases are being tracked on issue #67 