### PR TITLE
Handles multiple sections on insert message

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -209,7 +209,18 @@ fn handle_op_msg(request: &Request, msg: OpMsg) -> Result<Document, CommandExecu
 
     let section = msg.sections[0].clone();
     if section.kind == 0 {
-        return run(request, &section.documents);
+        let mut documents = section.documents.clone();
+        if msg.sections.len() > 1 {
+            for section in msg.sections[1..].iter() {
+                if let Some(identifier) = section.identifier.clone() {
+                    if identifier == "documents\0" {
+                        let new_doc = section.documents[0].clone();
+                        documents[0].insert("documents", Bson::Array(vec![new_doc.into()]));
+                    }
+                }
+            }
+        }
+        return run(request, &documents);
     }
 
     if section.kind == 1 {


### PR DESCRIPTION
This addresses a bug handling messages with multiple sections: one kind 0 message containing the command information and a subsequent section of kind 1 with only the documents.

This now works for insertions using IntelliJ IDEA Database console:

![image](https://user-images.githubusercontent.com/1371/187097617-50dd7c9f-f534-4bf5-ac1a-4ba6a04b6f1a.png)

Fixes #66 